### PR TITLE
Rotate backward

### DIFF
--- a/lib/decrypter.rb
+++ b/lib/decrypter.rb
@@ -13,7 +13,7 @@ class Decrypter < Crypter
 
   def result
     rslt = super
-    rslt[:encryption] = encrypt_string
+    rslt[:decryption] = decrypt_string
     rslt
   end
 

--- a/lib/rotation.rb
+++ b/lib/rotation.rb
@@ -1,7 +1,16 @@
 module Rotation
     def rotate_letter(letter, amount)
       index = @character_map.index(letter)
-      @character_map[(index + amount) % @character_map.length]
+      @character_map[(shift(index, amount)) % @character_map.length]
+    end
+
+    def shift(index, amount)
+      case @direction
+      when :forward
+        index + amount
+      when :backward
+        index - amount
+      end
     end
 
     def rotate_string_by_amounts(string, amounts)

--- a/test/decrypter_test.rb
+++ b/test/decrypter_test.rb
@@ -21,9 +21,8 @@ class DecrypterTest < Minitest::Test
   end
 
   def test_it_returns_a_hash_as_a_result
-    skip
     expected = {
-      encryption: "hello world",
+      decryption: "hello world",
       key: "02715",
       date: "040895"
     }

--- a/test/decrypter_test.rb
+++ b/test/decrypter_test.rb
@@ -17,8 +17,7 @@ class DecrypterTest < Minitest::Test
   end
 
   def test_it_decrypts_a_string
-    skip
-    assert_equal 'hello world', @e.decrypt_string
+    assert_equal 'hello world', @d.decrypt_string
   end
 
   def test_it_returns_a_hash_as_a_result


### PR DESCRIPTION
Rotation module now uses - instead of + when @direction of crypter is backward. Decryption tests pass.