### PR TITLE
Shift unit testing

### DIFF
--- a/test/rotation_test.rb
+++ b/test/rotation_test.rb
@@ -4,12 +4,17 @@ require './lib/crypter'
 class RotationTest < Minitest::Test
 
   def setup
-    @c = Crypter.new('thesestrings','donot','matterhere')
+    @c = Crypter.new('thesestrings','dont','matterhere')
   end
 
     def test_it_rotates_a_letter
       assert_equal 'b', @c.rotate_letter('a', 1)
       assert_equal 'a', @c.rotate_letter(' ', 1)
+    end
+
+    def test_a_decypter_rotates_a_letter_backward
+      decrypter = Decrypter.new('thesestrings','donot','matterhere')
+      assert_equal 'a', decrypter.rotate_letter('b', 1)
     end
 
     def test_it_rotates_a_string_by_amounts

--- a/test/rotation_test.rb
+++ b/test/rotation_test.rb
@@ -1,5 +1,6 @@
 require './test/test_helper'
 require './lib/crypter'
+require './lib/decrypter'
 
 class RotationTest < Minitest::Test
 
@@ -12,9 +13,18 @@ class RotationTest < Minitest::Test
       assert_equal 'a', @c.rotate_letter(' ', 1)
     end
 
-    def test_a_decypter_rotates_a_letter_backward
+    def test_a_decrypter_rotates_a_letter_backward
       decrypter = Decrypter.new('thesestrings','donot','matterhere')
       assert_equal 'a', decrypter.rotate_letter('b', 1)
+    end
+
+    def shift_sums_index_and_amount_by_default
+      assert_equal 5, @c.shift(3,2)
+    end
+
+    def test_shift_subtracts_index_and_amount_when_on_a_decrypter
+      decrypter = Decrypter.new('thesestrings','donot','matterhere')
+      assert_equal 1, decrypter.shift(3,2)
     end
 
     def test_it_rotates_a_string_by_amounts
@@ -29,8 +39,4 @@ class RotationTest < Minitest::Test
     def test_it_rotates_a_string_by_key_and_offsets
       assert_equal 'bldkc', @c.rotate_string_by_key_and_offsets('     ', '010',[1,2,3])
     end
-
-
-
-
 end


### PR DESCRIPTION
Though the integration tests were passing, the new helper method shift needed unit testing, which is added here. Justification for not writing unit tests first: I wanted to experiment to be sure my way of thinking was correct, so I wrote the code and unskipped the integration tests before writing unit tests.