### PR TITLE
Enigma key and date generation tests readded

### DIFF
--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -36,12 +36,14 @@ class EnigmaTest < Minitest::Test
     assert_equal secret, @e.decrypt(encryption, "02715")[:decryption]
   end
 
-  # def test_it_generates_a_random_key_if_no_key_given
-  #   @e.encrypt("This secret must be kept secret", nil, nil, false)
-  #   actual = @e.send(:encrypter).send(:key)
-  #   assert_equal 5, actual.size
-  #   assert_instance_of String, actual
-  #   assert actual[/\d{4}/]
-  # end
+  def test_it_generates_a_random_key_if_no_key_given
+    @e.encrypt("This secret must be kept secret", nil, nil, false)
+    actual = @e.send(:encrypter).send(:key)
+    assert_equal 5, actual.size
+    assert_instance_of String, actual
+    assert actual[/\d{4}/]
+  end
+
+
 
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -44,6 +44,10 @@ class EnigmaTest < Minitest::Test
     assert actual[/\d{4}/]
   end
 
-
+  def test_it_used_todays_date_if_no_date_given
+    @e.encrypt("This secret must be kept secret", nil, nil, false)
+    actual = @e.send(:encrypter).send(:date).date
+    assert_equal Date.today, actual
+  end
 
 end


### PR DESCRIPTION
Re adds two test that check key and date generation when none given on Enigma class. These are already unit tested, but not integration tested. One test had been commented out during refactoring and another had been deleted.